### PR TITLE
Add page as an option for woocommerce products displayed in pages via shortcode or page-builders.

### DIFF
--- a/admin/class-woo-title-limit-admin.php
+++ b/admin/class-woo-title-limit-admin.php
@@ -171,6 +171,14 @@ class Woo_Title_Limit_Admin {
 					'desc'  => __( 'Influences product titles on the home page.', 'woo-title-limit' ),
 				]
 			);
+			
+			$wtl_opt_obj->add_section(
+				[
+					'id'    => 'wtl_opt_page',
+					'title' => __( 'Pages', 'woo-title-limit' ),
+					'desc'  => __( 'Influences product titles on the pages.', 'woo-title-limit' ),
+				]
+			);			
 
 			$wtl_opt_obj->add_section(
 				[
@@ -285,6 +293,29 @@ class Woo_Title_Limit_Admin {
 			// Field: Checkbox.
 			$wtl_opt_obj->add_field(
 				'wtl_opt_home',
+				[
+					'id'   => 'dots',
+					'type' => 'checkbox',
+					'name' => __( 'Add "..." to the title', 'woo-title-limit' ),
+					'desc' => __( '', 'woo-title-limit' ),
+				]
+			);
+
+			$wtl_opt_obj->add_field(
+				'wtl_opt_page',
+				[
+					'id'                => 'count',
+					'type'              => 'number',
+					'name'              => __( 'Product Title length', 'woo-title-limit' ),
+					'desc'              => __( 'Set the limit for the product titles (amount of maximum characters).', 'woo-title-limit' ),
+					'default'           => 0,
+					'sanitize_callback' => 'intval',
+				]
+			);
+
+			// Field: Checkbox.
+			$wtl_opt_obj->add_field(
+				'wtl_opt_page',
 				[
 					'id'   => 'dots',
 					'type' => 'checkbox',

--- a/includes/class-woo-title-limit-activator.php
+++ b/includes/class-woo-title-limit-activator.php
@@ -38,10 +38,12 @@ class Woo_Title_Limit_Activator {
 			$wtl_count_category        = ( isset( $old_options['wtl_count_category'] ) ? $old_options['wtl_count_category'] : 0 );
 			$wtl_count_product         = ( isset( $old_options['wtl_count_product'] ) ? $old_options['wtl_count_product'] : 0 );
 			$wtl_count_home            = ( isset( $old_options['wtl_count_home'] ) ? $old_options['wtl_count_home'] : 0 );
+			$wtl_count_page            = ( isset( $old_options['wtl_count_page'] ) ? $old_options['wtl_count_page'] : 0 );
 			$wtl_checkbox_etc_shop     = ( isset( $old_options['wtl_checkbox_etc_shop'] ) && $old_options['wtl_checkbox_etc_shop'] == '1' ) ? 'on' : 'off';
 			$wtl_checkbox_etc_category = ( isset( $old_options['wtl_checkbox_etc_category'] ) && $old_options['wtl_checkbox_etc_category'] == '1' ) ? 'on' : 'off';
 			$wtl_checkbox_etc_product  = ( isset( $old_options['wtl_checkbox_etc_product'] ) && $old_options['wtl_checkbox_etc_product'] == '1' ) ? 'on' : 'off';
 			$wtl_checkbox_etc_home     = ( isset( $old_options['wtl_checkbox_etc_home'] ) && $old_options['wtl_checkbox_etc_home'] == '1' ) ? 'on' : 'off';
+			$wtl_checkbox_etc_page     = ( isset( $old_options['wtl_checkbox_etc_page'] ) && $old_options['wtl_checkbox_etc_page'] == '1' ) ? 'on' : 'off';
 			$wtl_checkbox_widgets      = ( isset( $old_options['wtl_checkbox_widgets'] ) && $old_options['wtl_checkbox_widgets'] == '1' ) ? 'on' : 'off';
 			$wtl_checkbox_wordcutter   = ( isset( $old_options['wtl_checkbox_wordcutter'] ) && $old_options['wtl_checkbox_wordcutter'] == '1' ) ? 'on' : 'off';
 
@@ -62,6 +64,10 @@ class Woo_Title_Limit_Activator {
 					'count' => $wtl_count_home,
 					'dots'  => $wtl_checkbox_etc_home,
 				],
+				'wtl_opt_page'     => [
+					'count' => $wtl_count_page,
+					'dots'  => $wtl_checkbox_etc_page,
+				],				
 				'wtl_opt_tag'      => [
 					'count' => 0,
 					'dots'  => 'off',

--- a/public/class-woo-title-limit-public.php
+++ b/public/class-woo-title-limit-public.php
@@ -140,6 +140,9 @@ class Woo_Title_Limit_Public {
 			if ( is_home() || is_front_page() ) {
 				return $this->shorten_title( 'home', $title );
 			}
+			if ( is_page() ) {
+				return $this->shorten_title( 'page', $title );
+			}			
 		}
 
 		return $title;


### PR DESCRIPTION
Love the plugin just needed same functionality on pages.
Please see pages: https://yds.com.au/just-arrived/ and https://yds.com.au/on-sale/
Would be greatfull if you could add.